### PR TITLE
V1.0.0 release: Set `list.highlightForeground`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.0
 
 - doc: README Update
+- Set `list.highlightForeground`
 
 ## v0.5.2
 

--- a/themes/hybrid-next-plus-color-theme.json
+++ b/themes/hybrid-next-plus-color-theme.json
@@ -82,12 +82,6 @@
 				"punctuation.definition",
 				"punctuation.section",
 				"punctuation.separator",
-				// "punctuation.definition.dictionary",
-				// "punctuation.definition.array",
-				// "punctuation.definition.block",
-				// "punctuation.definition.function-parameters",
-				// "punctuation.definition.method-parameters",
-				// "punctuation.definition.parameters",
 			],
 			"settings": {
 				"foreground": "#C5C8C6"

--- a/themes/hybrid-next-plus-color-theme.json
+++ b/themes/hybrid-next-plus-color-theme.json
@@ -555,7 +555,7 @@
 		{
 			"scope": "token.debug-token",
 			"settings": {
-				"foreground": "#b267e6"
+				"foreground": "#b294bb"
 			}
 		},
 		{

--- a/themes/hybrid-next-plus-color-theme.json
+++ b/themes/hybrid-next-plus-color-theme.json
@@ -33,7 +33,7 @@
 		"list.dropBackground": "#4796c2",
 		"list.focusBackground": "#4796c266",
 		"list.focusForeground": "#d5dde1",
-		"list.highlightForeground": "#4796c2",
+		"list.highlightForeground": "#ffffff",
 		"list.inactiveSelectionBackground": "#344149",
 		"minimap.findMatchHighlight": "#c5c8c666",
 		"panel.background": "#1d2428",


### PR DESCRIPTION
> We've update the focus state in the Quick Pick and suggest widget to better align with our tree widget styles. This introduces a few new color tokens that control focus foreground:
> - `list.focusHighlightForeground`
> - `quickInputList.focusForeground`
> - `editorSuggestWidget.selectedForeground`

ref. [Visual Studio Code May 2021 - Updated Quick Pick & suggest widget colors](https://code.visualstudio.com/updates/v1_57#_updated-quick-pick-suggest-widget-colors)